### PR TITLE
Adjust edges

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -1028,11 +1028,11 @@ export class OrgChart {
                   L ${mx} ${y}
                   L ${x} ${y}
                   L ${x + w * xrvs} ${y}
-                  C ${x + w * xrvs + r * xrvs} ${y} 
+                  L ${x + w * xrvs + r * xrvs} ${y} 
                     ${x + w * xrvs + r * xrvs} ${y} 
                     ${x + w * xrvs + r * xrvs} ${y + r * yrvs}
                   L ${x + w * xrvs + r * xrvs} ${ey - r * yrvs} 
-                  C ${x + w * xrvs + r * xrvs}  ${ey} 
+                  L ${x + w * xrvs + r * xrvs}  ${ey} 
                     ${x + w * xrvs + r * xrvs}  ${ey} 
                     ${ex - w * xrvs}  ${ey}
                   L ${ex} ${ey}
@@ -1065,10 +1065,10 @@ export class OrgChart {
                   L ${x} ${my}
                   L ${x} ${y}
                   L ${x} ${y + h * yrvs}
-                  C  ${x} ${y + h * yrvs + r * yrvs} ${x} ${y + h * yrvs + r * yrvs
+                  L  ${x} ${y + h * yrvs + r * yrvs} ${x} ${y + h * yrvs + r * yrvs
             } ${x + r * xrvs} ${y + h * yrvs + r * yrvs}
                   L ${x + w * xrvs + r * xrvs} ${y + h * yrvs + r * yrvs}
-                  C  ${ex}  ${y + h * yrvs + r * yrvs} ${ex}  ${y + h * yrvs + r * yrvs
+                  L  ${ex}  ${y + h * yrvs + r * yrvs} ${ex}  ${y + h * yrvs + r * yrvs
             } ${ex} ${ey - h * yrvs}
                   L ${ex} ${ey}
        `;

--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -1044,7 +1044,7 @@ export class OrgChart {
         const x = s.x;
         const y = s.y;
         const ex = t.x;
-        const ey = t.y;
+        const ey = t.y - 30; // changes how far the target y is
 
         let mx = m && m.x || x;
         let my = m && m.y || y;

--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -88,7 +88,7 @@ export class OrgChart {
             nodeWidth: d3Node => 250,
             nodeHeight: d => 150,
             siblingsMargin: d3Node => 20,
-            childrenMargin: d => 60,
+            childrenMargin: d => 90,
             neightbourMargin: (n1, n2) => 80,
             compactMarginPair: d => 100,
             compactMarginBetween: (d3Node => 20),


### PR DESCRIPTION
These changes:

* Make the path edge corners straight rather than curved (look up how SVG does this)
* Increases the height of the incoming path link from above. For a report node, the picture would previously cover it up. This change makes it long enough to not be covered up
* Increases the padding between reports in compact mode.

Ideally, we write cleaner code, expose function, and decouple disparate concerns. However, for the sake of time, we'll move ahead with the temporary fixes. Once we have more bandwidth, we should come back and improve this library in order to make understandability and contribution easier.