### PR TITLE
Hide links to the parent node

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -40,6 +40,7 @@ export class OrgChart {
             compact: true,
             rootMargin: 40,
             nodeDefaultBackground: 'none',
+            hiddenNodeIds: new Set(),
             connections: [],
             lastTransform: { x: 0, y: 0, k: 1 },
             nodeId: d => d.nodeId || d.id,
@@ -72,6 +73,10 @@ export class OrgChart {
                     .attr("marker-end", d => `url(#arrow-${d.from + "_" + d.to})`)
             },
             linkUpdate: function (d, i, arr) {
+                if (attrs.hiddenNodeIds.has(d.data.parentId)) {
+                    d3.select(this).attr('display', 'none')
+                    return 
+                }
                 d3.select(this)
                     .attr('stroke', d => d.data._upToTheRootHighlighted ? attrs.highlightedLinkColor : attrs.linkColor)
                     .attr('stroke-width', d => d.data._upToTheRootHighlighted ? '2' : '1')


### PR DESCRIPTION
This diff should just hide the paths if the parent node is specifically 

```js
const dummyRootNodeId = 'DUMMY_ROOT_NODE_ID'
```

However, though the node is hidden, it will still be clickable. That will happen in a different PR.

Test: ![no paths](https://user-images.githubusercontent.com/109986035/197303395-4d30a21b-14eb-48a2-8a74-e0804d6df545.gif)