### PR TITLE
Add closeSiblingNodes function

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -553,7 +553,7 @@ export class OrgChart {
     }
 
     // Recursively closes the siblings of the provided node and its ancestors.
-    closeSiblingNodes(node) {
+    closeNonReportingLineNodes(node) {
         const attrs = this.getChartState();
         const nodeFound = attrs.addedNodeIds.has(attrs.nodeId(node));
 
@@ -567,7 +567,7 @@ export class OrgChart {
             if (attrs.nodeId(child) === attrs.nodeId(node)) continue
             this.setExpansionFlagToChildren(child, false);
         }
-        this.closeSiblingNodes(parent);
+        this.closeNonReportingLineNodes(parent);
         this.updateNodesState()
     }
 

--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -552,6 +552,25 @@ export class OrgChart {
         return this;
     }
 
+    // Recursively closes the siblings of the provided node and its ancestors.
+    closeSiblingNodes(node) {
+        const attrs = this.getChartState();
+        const nodeFound = attrs.addedNodeIds.has(attrs.nodeId(node));
+
+        if (!nodeFound) return
+
+        const { parent } = node;
+
+        if (!parent.children) return
+    
+        for (const child of parent.children) {
+            if (attrs.nodeId(child) === attrs.nodeId(node)) continue
+            this.setExpansionFlagToChildren(child, false);
+        }
+        this.closeSiblingNodes(parent);
+        this.updateNodesState()
+    }
+
     // This function can be invoked via chart.removeNode API, and it removes node from tree at runtime
     removeNode(nodeId) {
         const attrs = this.getChartState();


### PR DESCRIPTION
* In order to prevent too many nodes being loaded on the screen, we want to introduce a way to close nodes as the user discovers other nodes.
* This function recursively closes the siblings of the node that is passed in as well as the siblings of each ancestor of the given node.

https://www.loom.com/share/199863452fd94d94a388fe8de8d7782b