### PR TITLE
Refresh added node ids on render

### DIFF
--- a/src/d3-org-chart.js
+++ b/src/d3-org-chart.js
@@ -354,9 +354,8 @@ export class OrgChart {
             return this;
         }
 
-        if (attrs.addedNodeIds.size < attrs.data.length) {
-            attrs.data.forEach((d) => attrs.addedNodeIds.add(attrs.nodeId(d)))
-        }
+        attrs.addedNodeIds.clear();
+        attrs.data.forEach((d) => attrs.addedNodeIds.add(attrs.nodeId(d)))
 
         //Drawing containers
         const container = d3.select(attrs.container);


### PR DESCRIPTION
### Motivation

We want to introduce a way to show multiple views of the org chart. That is, separate views with a distinct set of nodes in each. There should be no overlap. In the implementation, I discovered that even thought the data (`attrs.data`) would get reset (referring to [this line](https://cs.github.com/askscio/scio/blob/71197d9f0ab55b853a2e836fe15d4be89d3ca39d/typescript/web/directory/components/D3OrgChartWrapper.tsx#L197)), the internal implementation of added nodes (`attrs.addedNodeIds`) would not. This change makes it so that the added nodes are reset to be whatever `attrs.data` is on each render. Note: `addedNodeIds` was a concept that we added to this package. Previously, the package would iterate through each node in `attrs.data`. With `addedNodeIds`, we can do a `O(1)` check on the set to see if a node exists in the tree.

I was concerned about performance given that this would run on each render, but it doesn't seem to be an issue. Tested on salessavvy. See the demo below.

---

### Demo

https://www.loom.com/share/b636ad795c664eda878fe31ea680b436